### PR TITLE
Tip 235 is VNC not RDP

### DIFF
--- a/blog/tip235.md
+++ b/blog/tip235.md
@@ -1,7 +1,7 @@
 ---
 type: post
-title: "Tip 235 - Remote Desktop on Azure Linux VMs"
-excerpt: "Remote Desktop  on Azure Linux VMs"
+title: "Tip 235 - VNC on Azure Linux VMs"
+excerpt: "VNC on Azure Linux VMs"
 tags: [azure, vnc, linux, remote-desktop]
 share: true
 date: 2019-11-24
@@ -19,7 +19,7 @@ date: 2019-11-24
 Author: Kumar Allamraju
 Twitter: [@kumarallamraju](https://twitter.com/kumarallamraju)
 
-Are you a MAC or Windows User? A big fan of GUI? Tired of SSH'ing to Linux VMs?  What if you want to browse the web? Remote Desktop comes to the rescue. 
+Are you a MAC or Windows User? A big fan of GUI? Tired of SSH'ing to Linux VMs?  What if you want to browse the web? VNC comes to the rescue. 
 
 The following article was written for Ubuntu VM but a similar process applies to other Linux flavors as well.
 
@@ -100,7 +100,7 @@ And voilà! You can now use your favorite Desktop environment on your Azure VM i
 
 #### Conclusion
 
-Remote Desktop Tool like Gnome provides a rich desktop experience, packed with features that will make you more productive. This is especially useful for native Windows or MAC users. Go ahead and give it a try!!
+The VNC tool provides a rich desktop experience, packed with features that will make you more productive. This is especially useful for native Windows or MAC users. Go ahead and give it a try!!
 
 #### Reference Links to Gnome and Xfce
 


### PR DESCRIPTION
I updated this tip to correctly reference the method of access as VNC, not RDP. VNC is not the same as Remote Desktop, and calling it such will confuse people. I updated the article to correctly be titled "VNC on Azure Linux VMs".

If you're interested in Remote Desktop on Azure Linux VMs, then please check out these articles:

- <https://build5nines.com/how-to-setup-an-ubuntu-linux-vm-in-azure-with-remote-desktop-rdp-access/>

- <https://docs.microsoft.com/en-us/azure/virtual-machines/linux/use-remote-desktop>