### PR TITLE
Corrected instructions for clarity

### DIFF
--- a/blog/tip140.md
+++ b/blog/tip140.md
@@ -31,7 +31,7 @@ You'll see something similar to this screen once it has finished processing.
 
 <img :src="$withBase('/files/sqlazure4.png')">
 
-Now ensure you are connected to your local target SQL server instance (or SQL Azure instance) and right-click on the **Database** -> click **Tasks** > **Import data-tier application** and select the .backpac file that you created earlier. 
+Now ensure you are connected to your local target SQL server instance (or SQL Azure instance) and right-click on **Databases** (the parent folder of your actual database) -> click **Tasks** > **Import data-tier application** and select the .backpac file that you created earlier. 
 
 <img :src="$withBase('/files/sqlazure3.png')">
 


### PR DESCRIPTION
Updated reference to Import data-tier application as the user does not click on "the database" they need to click on "Databases" folder. It took me some time to find this option as I trusted the Microsoft Docs.