### PR TITLE
adds header Authorization = Bearer {{bearerToken}}

### DIFF
--- a/blog/tip223.md
+++ b/blog/tip223.md
@@ -105,7 +105,9 @@ You might be thinking this is a lot of work. But this is just a one time setup i
 
 After getting the bearer token you can execute the Azure REST APIs for getting Resource Groups, details about a particular Resource Group, VNets etc..
 
-As an example I issued a GET request to get details about a resource group in my azure subscription. See the screenshot below
+As an example I issued a GET request to get details about a resource group in my azure subscription. In the Header section add a key "Authorization" with value Bearer {{bearerToken}}
+
+See the screenshot below
 
 <img :src="$withBase('/files/azurepostman-file4.jpg')">
 


### PR DESCRIPTION
Before issuing GET request for the resource group you need to add a header for Authorization to use {{bearerToken}} value set in the test section above. You may already have it set but this article does not call for it and without setting that value it isn't working. You may want to take another screenshot and add it.