### PR TITLE
Changes for Azure CLI in Bash with key vault

### DIFF
--- a/blog/tip275.md
+++ b/blog/tip275.md
@@ -11,32 +11,35 @@ date: 2020-07-30 18:30:00
 
 :fire: Make sure you [star the repo](http://azuredev.tips?WT.mc_id=azure-azuredevtips-micrum) to keep up to date with new tips and tricks.
 
-:bulb: Learn more : [Microsoft Azure Key Vault](https://azure.microsoft.com/services/key-vault?WT.mc_id=azure-azuredevtips-micrum). 
+:bulb: Learn more : [Microsoft Azure Key Vault](https://azure.microsoft.com/services/key-vault?WT.mc_id=azure-azuredevtips-micrum).
 
-:tv: Watch the video : [Getting started with Azure Key Vault](https://azure.microsoft.com/en-us/resources/videos/azure-key-vault-developer-quick-start/).
+:tv: Watch the video : [Getting started with Azure Key Vault](https://azure.microsoft.com/resources/videos/azure-key-vault-developer-quick-start/).
 
 :::
 
 #### Using secrets in scripts
 
-When you write deployment scripting you often need secrets / passwords. Using these secrets is often done by using variables and storing the plain text password or secure object (which is still security through obscurity). In some cases people paramatarize the values and have to input the secrets / passwords upon runtime. If you're working with a large number of secrets the latter can be quite time consuming. 
-
+When you write deployment scripting you often need secrets / passwords. Using these secrets is often done by using variables and storing the plain text password or secure object (which is still security through obscurity). In some cases people parameterize the values and have to input the secrets / passwords upon runtime. If you're working with a large number of secrets the latter can be quite time consuming.
 
 #### 1. Leveraging the Azure Key Vault
-When using Microsoft Azure, it's a best practice to store your secrets in the Azure Key Vault. This can also be done when scripting your deployments. If you're deploying ARM Templates, you can query the key vault directly during the deployment (https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/key-vault-parameter?tabs=azure-cli) and this is often the most secure way.
+
+When using Microsoft Azure, it's a best practice to store your secrets in the Azure Key Vault. This can also be done when scripting your deployments. If you're deploying ARM Templates, you can query the key vault directly during the deployment (<https://docs.microsoft.com/azure/azure-resource-manager/templates/key-vault-parameter?tabs=azure-cli>) and this is often the most secure way.
 
 However, sometimes you're just not deploying using ARM templates or you're using a combination of tools. Maybe you're not even deploying to Azure and you just need a place to store your secrets. Key Vault is there for you :)
 
 #### 2. Code samples
-Note that the code requires you t be logged in to Azure using either Azure PowerShell or Azure CLI (depending on your preference).
+
+Note that the code requires you to be logged in to Azure using either Azure PowerShell or Azure CLI (depending on your preference).
+
+##### PowerShell version
 
 The following code will retrieve all the secrets from your Azure KeyVault and store them in the hash table "*$keys*".
 
-Upon succesful execution you can request the secrets from the table by simple parsing "*$keys.NameOfYourKeyVaultSecret*"
+Upon successful execution you can request the secrets from the table by simple parsing "*$keys.NameOfYourKeyVaultSecret*"
 
 For example "*$keys.storageAccountkey*" would return the secret value of the "storageAccountKey" as stored in the Azure KeyVault.
 
-```
+```powershell
 $keyvaultName = 'KeyVaultName'
 $secrets = Get-AzKeyVaultSecret -VaultName $keyvaultName
 
@@ -44,24 +47,28 @@ $keys =@{}
 foreach ($secret in $secrets)
     {
         $secretName = $secret.name
-        
+
         $key = (Get-AzKeyVaultSecret -VaultName $keyvaultName -name $secretName).SecretValueText
         $keys.Add("$secretName", "$key")
     }
 
 ```
+
 ##### Azure CLI version
 
-```
-$keyvaultName = 'KeyVaultName'
-$secrets = az keyvault secret list --vault-name $keyvaultName |convertFrom-Json
-    
-$keys =@{}
-foreach ($secret in $secrets)
-    {
-        $secretName = $secret.name
+The following code will retrieve all the secrets from your Azure KeyVault and store them in the associative array, secrets. Associative arrays were introduced with Bash version 4.
 
-        $key = az keyvault secret show --vault-name $keyvaultName --name $secretName --query value
-        $keys.Add("$secretName", "$key")
-    }
+Upon successful execution you can request the secrets from the table by simple parsing `${secrets[NameOfYourKeyVaultSecret]}`.
+
+For example `${secrets[storageAccountKey]}` would return the secret value of the "storageAccountKey" as stored in the Azure KeyVault.
+
+```bash
+keyvaultName='KeyVaultName'
+
+declare -A secrets
+
+for name in $(az keyvault secret list --vault-name $keyvaultName --query "[].name" --output tsv)
+do
+  secrets["$name"]=$(az keyvault secret show --name $name --vault-name $keyvaultName --query value --output tsv)
+done
 ```


### PR DESCRIPTION
The example was for Azure CLI use in PowerShell, which is a less likely combination than the Azure CLI in Bash that I have in this PR.

Also tidied up some content based on markdownlint and code spell checker.