### PR TITLE
Added a period after the docker build command

### DIFF
--- a/blog/tip277.md
+++ b/blog/tip277.md
@@ -120,7 +120,7 @@ docker login
 ```
 3. Now use the following command to build the container with the Function App in it. The myfunctionapp:v1 represents the name of the container and the tag (v1):
 ```
-docker build -t myfunctionapp:v1
+docker build -t myfunctionapp:v1 .
 ```
 The Function App should build and the container should be created now. With this last step, we've made sure that the Function compiles into a container. 
 


### PR DESCRIPTION
docker requires a reference to the directory that the Dockerfile is in. "." represents the current directory in this example. Without the period it will result in the following error:
"docker build" requires exactly 1 argument.