### PR TITLE
Update tip278.md

### DIFF
--- a/blog/tip278.md
+++ b/blog/tip278.md
@@ -64,9 +64,12 @@ az aks get-credentials -g <yourresourcegroup> -n <youraksclustername> --overwrit
 ```
 kubectl get nodes
 ```
-4. Alright. Now we install KEDA on AKS. This will enable the container to behave like an Azure Function running in consumption mode. It will be able to scale to 0 instances when needed and will automatically scale up when the the Function needs to run more. You can install KEDA on AKS with this command:
+4. Alright. Now we install KEDA on AKS. This will enable the container to behave like an Azure Function running in consumption mode. It will be able to scale to 0 instances when needed and will automatically scale up when the the Function needs to run more. You can install KEDA using the helm charts as provided by KEDA. This does require you to [install helm](https://github.com/helm/helm/releases). You can install KEDA on AKS with the following command:
 ```
-func kubernetes install --namespace keda
+helm repo add kedacore https://kedacore.github.io/charts
+helm repo update
+kubectl create namespace keda
+helm install keda kedacore/keda --namespace keda
 ```
 5. When KEDA is installed, we can deploy the container to AKS and start running it. The command below builds the container with the Function in it and deploys it to AKS. It leverages the docker CLI to build and deploy the image. Be sure to have docker connected to your account with **docker login**. Replace the \<name-of-function-deployment\> with the name of your Function app. And replace \<container-registry-username\>  with your username for the Docker container registry
 ```


### PR DESCRIPTION
Using the Azure Function Core tools install KEDA 1.1.0. We're currently at 2. Most public documentation samples are not working with KEDA 1.1.0. Install with Helm is currently the way to go until the AzFunction Core Tools are updated (https://github.com/Azure/azure-functions-core-tools/pull/2289)