### PR TITLE
Fix typo in Azure Metadata tip

### DIFF
--- a/blog/tip80.md
+++ b/blog/tip80.md
@@ -71,9 +71,9 @@ static void GetMetadata(BlobContainerClient container)
 {
     //retrieve container metadata
     BlobContainerProperties properties = container.GetProperties();
-    foreach (var metadate in properties.Metadata)
+    foreach (var metadata in properties.Metadata)
     {
-        Console.WriteLine(string.Format($"{metadate.Key}: {metadate.Value}"));
+        Console.WriteLine(string.Format($"{metadata.Key}: {metadata.Value}"));
     }
 }
 ```

--- a/blog/tip80.md
+++ b/blog/tip80.md
@@ -54,11 +54,11 @@ static void SetMetadata(BlobContainerClient container)
     //clear metadata
     container.SetMetadata(new Dictionary<string, string>());
 
-    Dictionary<string, string> metaData = new Dictionary<string, string>(2);
-    metaData.Add("Owner", "Michael Crump");
-    metaData["LastUpdated"] = DateTime.Now.ToString();
+    Dictionary<string, string> metadata = new Dictionary<string, string>(2);
+    metadata.Add("Owner", "Michael Crump");
+    metadata["LastUpdated"] = DateTime.Now.ToString();
     //set metadata
-    container.SetMetadata(metaData);
+    container.SetMetadata(metadata);
 }
 ```
 


### PR DESCRIPTION
1. Fix a single typo (`metadate` -> `metadata`) in [Blob Metadata](https://microsoft.github.io/AzureTipsAndTricks/blog/tip80.html) tip code sample
2. Remove upper-case in "Data" (`metaData` -> `metadata`) to be consistent with all other usages in the repo