### PR TITLE
Remove the free trial

### DIFF
--- a/blog/tip353.md
+++ b/blog/tip353.md
@@ -42,7 +42,7 @@ Azure IoT Central provides IoT-as-a-service. Let's try it out.
 
 4. This opens the **"About your app"** blade
    1. IoT Central suggests a name and URL prefix. You can leave them as they are
-   2. Choose **Free** for the **Pricing plan**
+   2. Choose **Standard 2** for the **Pricing plan**
    3. In Billing Info, select your **Azure Active Directory**
    4. Select the **Azure Subscription** that you want to use
    5. Select a **Location** for the application


### PR DESCRIPTION
Hello, IoT Central no longer offers the free trial option. Please edit it out of this page. Let me know if you have more questions.